### PR TITLE
Introduce template engine abstraction

### DIFF
--- a/src/Back/Api/Engine.js
+++ b/src/Back/Api/Engine.js
@@ -2,7 +2,8 @@
  * API interface for a template rendering engine (Mustache, Nunjucks, etc.).
  *
  * Implementations must provide a `perform()` method for processing template content
- * with context and optional engine-specific options.
+ * with context and optional engine-specific options. Engines should also expose
+ * their result codes via `getResultCodes()`.
  *
  * @interface
  */
@@ -17,6 +18,15 @@ export default class Fl32_Tmpl_Back_Api_Engine {
     async perform({template, data, options}) {
         throw new Error('Method not implemented');
     }
+
+    /**
+     * Get engine-specific result codes.
+     *
+     * @returns {object} Enumeration of result codes supported by the engine.
+     */
+    getResultCodes() {
+        throw new Error('Method not implemented');
+    }
 }
 
 /**
@@ -28,4 +38,9 @@ export default class Fl32_Tmpl_Back_Api_Engine {
  * @typedef {object} Fl32_Tmpl_Back_Api_Engine.Result
  * @property {string} resultCode - Status code describing the render result.
  * @property {string|null} content - Rendered output string or null if rendering failed.
+ *
+ * @typedef {object} Fl32_Tmpl_Back_Api_Engine.ResultCodes
+ * @property {string} SUCCESS - Rendering completed successfully.
+ * @property {string} TMPL_IS_EMPTY - Template is empty.
+ * @property {string} UNKNOWN_ERROR - Unexpected error occurred.
  */

--- a/src/Back/Service/Render.js
+++ b/src/Back/Service/Render.js
@@ -1,27 +1,22 @@
 /**
- * Renders templates using a configured engine (Mustache or Nunjucks).
- * Handles template loading and processing pipeline.
+ * Renders templates using an abstracted template engine.
+ * Handles template loading and delegates rendering to the injected engine.
  */
 export default class Fl32_Tmpl_Back_Service_Render {
     /* eslint-disable jsdoc/check-param-names */
     /**
      * @param {Fl32_Tmpl_Back_Logger} logger - Error logger.
-     * @param {Fl32_Tmpl_Back_Config} config - Engine configuration.
+     * @param {Fl32_Tmpl_Back_Api_Engine} engine - Template engine implementation.
      * @param {Fl32_Tmpl_Back_Act_File_Find} actFind - Template file locator.
      * @param {Fl32_Tmpl_Back_Act_File_Load} actLoad - Template file loader.
-     * @param {Fl32_Tmpl_Back_Service_Engine_Mustache} servMustache - Mustache renderer.
-     * @param {Fl32_Tmpl_Back_Service_Engine_Nunjucks} servNunjucks - Nunjucks renderer.
-     * @param {typeof Fl32_Tmpl_Back_Enum_Engine} ENGINE - Engine types enum.
+     *
      */
     constructor(
         {
             Fl32_Tmpl_Back_Logger$: logger,
-            Fl32_Tmpl_Back_Config$: config,
+            Fl32_Tmpl_Back_Api_Engine$: engine,
             Fl32_Tmpl_Back_Act_File_Find$: actFind,
             Fl32_Tmpl_Back_Act_File_Load$: actLoad,
-            Fl32_Tmpl_Back_Service_Engine_Mustache$: servMustache,
-            Fl32_Tmpl_Back_Service_Engine_Nunjucks$: servNunjucks,
-            Fl32_Tmpl_Back_Enum_Engine$: ENGINE,
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
@@ -37,7 +32,7 @@ export default class Fl32_Tmpl_Back_Service_Render {
         this.getResultCodes = () => RESULT;
 
         /**
-         * Renders template using configured engine.
+         * Renders template using the injected engine.
          * @param {object} args - Rendering parameters.
          * @param {Fl32_Tmpl_Back_Dto_Target.Dto} args.target - Template target.
          * @param {string} [args.template] - Raw template string.
@@ -72,25 +67,17 @@ export default class Fl32_Tmpl_Back_Service_Render {
                 }
                 if (resultCode !== RESULT.PATH_NOT_FOUND) {
                     if (templateContent) {
-                        if (config.getEngine() === ENGINE.MUSTACHE) {
-                            // Render the template using Mustache
-                            const {resultCode: renderResult, content} = await servMustache.perform({
-                                template: templateContent,
-                                data,
-                                options,
-                            });
-                            resultContent = content;
-                        } else {
-                            // Use Nunjucks by default
-                            const ext = Object.assign({}, options, {locale: target?.locales?.user});
-                            const {resultCode: renderResult, content} = await servNunjucks.perform({
-                                template: templateContent,
-                                data,
-                                options: ext,
-                            });
-                            resultContent = content;
-                        }
-                        resultCode = RESULT.SUCCESS;
+                        const ext = Object.assign({}, options, {locale: target?.locales?.user});
+                        const resCodes = engine.getResultCodes();
+                        const {resultCode: renderResult, content} = await engine.perform({
+                            template: templateContent,
+                            data,
+                            options: ext,
+                        });
+                        resultContent = content;
+                        if (renderResult === resCodes.SUCCESS) resultCode = RESULT.SUCCESS;
+                        else if (renderResult === resCodes.TMPL_IS_EMPTY) resultCode = RESULT.TMPL_IS_EMPTY;
+                        else resultCode = RESULT.UNKNOWN_ERROR;
                     } else {
                         resultCode = RESULT.TMPL_IS_EMPTY;
                     }

--- a/src/Demo/Back/Di/Replace/Engine.js
+++ b/src/Demo/Back/Di/Replace/Engine.js
@@ -1,0 +1,24 @@
+/**
+ * Example DI configuration chunk replacing the abstract template engine
+ * with a concrete implementation. Applications can provide a similar
+ * file to switch engines without modifying the core package.
+ */
+export default class Fl32_Tmpl_Demo_Back_Di_Replace_Engine {
+    /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
+    /**
+     * @param {TeqFw_Di_Container} container
+     * @param {typeof import('@teqfw/di/src/Pre/Replace.js')} Replace
+     */
+    constructor(
+        {
+            TeqFw_Di_Container$: container,
+            '@teqfw/di/src/Pre/Replace.js': Replace,
+        }
+    ) {
+        /* eslint-enable jsdoc/require-param-description,jsdoc/check-param-names */
+        const chunk = new Replace();
+        chunk.add('Fl32_Tmpl_Back_Api_Engine', 'Fl32_Tmpl_Back_Service_Engine_Mustache');
+        container.getPreProcessor().addChunk(chunk);
+    }
+}
+

--- a/test/unit/Back/Service/Render.test.mjs
+++ b/test/unit/Back/Service/Render.test.mjs
@@ -11,21 +11,17 @@ function buildTestContainerWithMocks(overrides = {}) {
     const container = buildTestContainer();
     const logger = {exception: []};
 
-    // Mock template engines
-    container.register('Fl32_Tmpl_Back_Service_Engine_Mustache$', overrides.mustache || {
-        perform: async ({template, data}) => {
-            return {
-                resultCode: 'SUCCESS',
-                content: `[${template.trim()}] with ${JSON.stringify(data)}`,
-            };
-        },
-    });
-
-    container.register('Fl32_Tmpl_Back_Service_Engine_Nunjucks$', overrides.nunjucks || {
+    // Mock template engine implementing the API
+    container.register('Fl32_Tmpl_Back_Api_Engine$', overrides.engine || {
+        getResultCodes: () => ({
+            SUCCESS: 'SUCCESS',
+            TMPL_IS_EMPTY: 'TMPL_IS_EMPTY',
+            UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+        }),
         perform: async ({template, data, options}) => {
             return {
                 resultCode: 'SUCCESS',
-                content: `Nunjucks: ${template.trim()} | ${JSON.stringify(data)} | ${JSON.stringify(options)}`,
+                content: `Default: ${template.trim()} | ${JSON.stringify(data)} | ${JSON.stringify(options)}`,
             };
         },
     });
@@ -53,16 +49,7 @@ function buildTestContainerWithMocks(overrides = {}) {
         exception: (...args) => logger.exception.push(args),
     });
 
-    // Mock config
-    container.register('Fl32_Tmpl_Back_Config$', overrides.config || {
-        getEngine: () => 'mustache',
-    });
 
-    // Enum
-    container.register('Fl32_Tmpl_Back_Enum_Engine$', {
-        MUSTACHE: 'mustache',
-        NUNJUCKS: 'nunjucks',
-    });
 
     return {container, logger};
 }
@@ -131,10 +118,20 @@ test.describe('Fl32_Tmpl_Back_Service_Render', () => {
             assert.strictEqual(content, null);
         });
 
-        test('should render using Nunjucks if engine is configured', async () => {
+        test('should render using a custom engine implementation', async () => {
             const {container} = buildTestContainerWithMocks({
-                config: {
-                    getEngine: () => 'nunjucks',
+                engine: {
+                    getResultCodes: () => ({
+                        SUCCESS: 'SUCCESS',
+                        TMPL_IS_EMPTY: 'TMPL_IS_EMPTY',
+                        UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+                    }),
+                    perform: async ({template, data, options}) => {
+                        return {
+                            resultCode: 'SUCCESS',
+                            content: `Nunjucks: ${template.trim()} | ${JSON.stringify(data)} | ${JSON.stringify(options)}`,
+                        };
+                    },
                 },
             });
 


### PR DESCRIPTION
## Summary
- define common API for template engines
- decouple render service from concrete engines and use the API
- add example DI replacement chunk
- update unit tests for new engine contract

## Testing
- `npm run eslint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a992c02e4832da264c9c3eba174f3