### PR TITLE
Implement simple DI adapter and template engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ A universal package for managing and rendering text templates in Node.js applica
 
 When using this package, the application **must implement the interface `Fl32_Tmpl_Back_Api_Adapter`**. This adapter interface declares a method `getEngine()` that returns an instance of a template engine conforming to the interface `Fl32_Tmpl_Back_Api_Engine`.
 
-The application is responsible for configuring which template engine implementation to use by specifying dependencies in the project's `package.json`. The `getEngine()` method can return one of the two available engine implementations provided by the package:
+The application is responsible for configuring which template engine implementation to use by specifying dependencies in the project's `package.json`. The `getEngine()` method can return one of the available engine implementations provided by the package:
 
 - `Fl32_Tmpl_Back_Service_Engine_Mustache`
 - `Fl32_Tmpl_Back_Service_Engine_Nunjucks`
+- `Fl32_Tmpl_Back_Service_Engine_Simple`
 
 Alternatively, the application can implement its own custom template engine, provided it satisfies the `Fl32_Tmpl_Back_Api_Engine` interface.
 

--- a/src/Back/Di/Adapter.js
+++ b/src/Back/Di/Adapter.js
@@ -1,0 +1,21 @@
+/**
+ * Dependency injection adapter that exposes a template engine instance.
+ *
+ * @implements {Fl32_Tmpl_Back_Api_Adapter}
+ */
+export default class Fl32_Tmpl_Back_Di_Adapter {
+    /* eslint-disable jsdoc/check-param-names */
+    /**
+     * @param {Fl32_Tmpl_Back_Api_Engine} Fl32_Tmpl_Back_Service_Engine_Simple$
+     */
+    constructor({Fl32_Tmpl_Back_Service_Engine_Simple$: engine}) {
+        /* eslint-enable jsdoc/check-param-names */
+        /**
+         * Returns injected template engine.
+         * @returns {Fl32_Tmpl_Back_Api_Engine}
+         */
+        this.getEngine = function () {
+            return engine;
+        };
+    }
+}

--- a/src/Back/Service/Engine/Simple.js
+++ b/src/Back/Service/Engine/Simple.js
@@ -1,0 +1,45 @@
+/**
+ * @implements {Fl32_Tmpl_Back_Api_Engine}
+ */
+export default class Fl32_Tmpl_Back_Service_Engine_Simple {
+    /* eslint-disable jsdoc/check-param-names */
+    /**
+     * @param {Fl32_Tmpl_Back_Logger} logger
+     */
+    constructor({Fl32_Tmpl_Back_Logger$: logger}) {
+        /* eslint-enable jsdoc/check-param-names */
+        this.render = async function (
+            {template, data = {}, options = {}}
+        ) {
+            let resultCode = RESULT.UNKNOWN_ERROR;
+            let content = null;
+            try {
+                if (template) {
+                    content = template.replace(/{{\s*([\w]+)\s*}}/g, (m, key) => {
+                        const val = data[key];
+                        return (typeof val === 'string' || typeof val === 'number')
+                            ? String(val)
+                            : m;
+                    });
+                    resultCode = RESULT.SUCCESS;
+                } else {
+                    resultCode = RESULT.TMPL_IS_EMPTY;
+                }
+            } catch (error) {
+                logger.exception(error);
+            }
+            return {resultCode, content};
+        };
+    }
+}
+
+/**
+ * Result codes for template rendering operations.
+ * @memberOf Fl32_Tmpl_Back_Service_Engine_Simple
+ */
+const RESULT = {
+    SUCCESS: 'SUCCESS',
+    TMPL_IS_EMPTY: 'TMPL_IS_EMPTY',
+    UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+};
+Object.freeze(RESULT);

--- a/test/unit/Back/Di/Adapter.test.mjs
+++ b/test/unit/Back/Di/Adapter.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'assert';
+import {buildTestContainer} from '../../common.js';
+
+test.describe('Fl32_Tmpl_Back_Di_Adapter', () => {
+    test('should return injected engine instance', async () => {
+        const container = buildTestContainer();
+
+        const engine = {id: 'engine'};
+        container.register('Fl32_Tmpl_Back_Service_Engine_Simple$', engine);
+
+        const adapter = await container.get('Fl32_Tmpl_Back_Di_Adapter$');
+
+        assert.strictEqual(adapter.getEngine(), engine);
+    });
+});

--- a/test/unit/Back/Service/Engine/Simple.test.mjs
+++ b/test/unit/Back/Service/Engine/Simple.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'assert';
+import {buildTestContainer} from '../../../common.js';
+
+test.describe('Fl32_Tmpl_Back_Service_Engine_Simple', () => {
+    test('basic render', async () => {
+        const container = buildTestContainer();
+        container.register('Fl32_Tmpl_Back_Logger$', {
+            exception: () => {
+                throw new Error('Should not be called');
+            },
+        });
+        const engine = await container.get('Fl32_Tmpl_Back_Service_Engine_Simple$');
+        const {resultCode, content} = await engine.render({
+            template: 'Hi, {{name}}!',
+            data: {name: 'Bob'},
+        });
+        assert.strictEqual(resultCode, 'SUCCESS');
+        assert.strictEqual(content, 'Hi, Bob!');
+    });
+
+    test('returns TMPL_IS_EMPTY when template is empty', async () => {
+        const container = buildTestContainer();
+        container.register('Fl32_Tmpl_Back_Logger$', {exception: () => {}});
+        const engine = await container.get('Fl32_Tmpl_Back_Service_Engine_Simple$');
+        const {resultCode, content} = await engine.render({template: ''});
+        assert.strictEqual(resultCode, 'TMPL_IS_EMPTY');
+        assert.strictEqual(content, null);
+    });
+
+    test('logs exception and returns UNKNOWN_ERROR on failure', async () => {
+        const container = buildTestContainer();
+        const log = {exception: []};
+        container.register('Fl32_Tmpl_Back_Logger$', {
+            exception: (...args) => log.exception.push(args),
+        });
+        const engine = await container.get('Fl32_Tmpl_Back_Service_Engine_Simple$');
+        const {resultCode, content} = await engine.render({template: 5});
+        assert.strictEqual(resultCode, 'UNKNOWN_ERROR');
+        assert.strictEqual(content, null);
+        assert.strictEqual(log.exception.length, 1);
+        assert.ok(log.exception[0][0] instanceof Error);
+    });
+});


### PR DESCRIPTION
## Summary
- add a dependency injection adapter for template engines
- implement a simple placeholder engine
- document the new engine in README
- add unit tests for the adapter and the simple engine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d254fc818832dbe5c96ff41370456