### PR TITLE
Add unified web template renderer

### DIFF
--- a/src/Back/Service/Render/Web.js
+++ b/src/Back/Service/Render/Web.js
@@ -1,0 +1,50 @@
+export default class Fl32_Tmpl_Back_Service_Render_Web {
+    /* eslint-disable jsdoc/check-param-names */
+    /**
+     * @param {Fl32_Tmpl_Back_Dto_Target} dtoTarget - Target DTO factory.
+     * @param {Fl32_Tmpl_Back_Config} config - Templates configuration.
+     * @param {Fl32_Tmpl_Back_Service_Render} serviceRender - Base render service.
+     */
+    constructor(
+        {
+            Fl32_Tmpl_Back_Dto_Target$: dtoTarget,
+            Fl32_Tmpl_Back_Config$: config,
+            Fl32_Tmpl_Back_Service_Render$: serviceRender,
+        }
+    ) {
+        /* eslint-enable jsdoc/check-param-names */
+        /**
+         * Render a localized web template.
+         * @param {object} args - Rendering parameters.
+         * @param {string} args.name - Template filename with extension.
+         * @param {string} args.locale - User requested locale.
+         * @param {string} [args.pkg] - Optional npm package name.
+         * @param {object} [args.data] - Template context data.
+         * @param {object} [args.options] - Engine specific render options.
+         * @returns {Promise<{resultCode:string, content:string|null}>}
+         */
+        this.perform = async function (
+            {
+                name,
+                locale,
+                pkg = '',
+                data = {},
+                options = {},
+            }
+        ) {
+            const defaultLocale = config.getDefaultLocale();
+            const target = dtoTarget.create({
+                type: 'web',
+                name,
+                pkg,
+                locales: {
+                    user: locale,
+                    app: defaultLocale,
+                    pkg: defaultLocale,
+                },
+            });
+
+            return serviceRender.perform({target, data, options});
+        };
+    }
+}

--- a/test/unit/Back/Service/Render_Web.test.mjs
+++ b/test/unit/Back/Service/Render_Web.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'assert';
+import {buildTestContainer} from '../../common.js';
+
+test.describe('Fl32_Tmpl_Back_Service_Render_Web', () => {
+
+    test('should build Target DTO and delegate to Render service', async () => {
+        const container = buildTestContainer();
+        const logs = {createArgs: null, performArgs: null};
+
+        // Mock dependencies
+        container.register('Fl32_Tmpl_Back_Dto_Target$', {
+            create: (args) => {logs.createArgs = args; return args;},
+        });
+        container.register('Fl32_Tmpl_Back_Config$', {
+            getDefaultLocale: () => 'en',
+        });
+        container.register('Fl32_Tmpl_Back_Service_Render$', {
+            perform: async ({target, data, options}) => {
+                logs.performArgs = {target, data, options};
+                return {resultCode: 'SUCCESS', content: 'ok'};
+            },
+        });
+
+        const service = await container.get('Fl32_Tmpl_Back_Service_Render_Web$');
+
+        const params = {
+            name: 'index.html',
+            locale: 'en-US',
+            pkg: '@vendor/cms',
+            data: {title: 'Hello'},
+            options: {partials: {}},
+        };
+
+        const {resultCode, content} = await service.perform(params);
+
+        assert.strictEqual(resultCode, 'SUCCESS');
+        assert.strictEqual(content, 'ok');
+        assert.deepStrictEqual(logs.createArgs, {
+            type: 'web',
+            name: 'index.html',
+            pkg: '@vendor/cms',
+            locales: {user: 'en-US', app: 'en', pkg: 'en'},
+        });
+        assert.deepStrictEqual(logs.performArgs, {
+            target: logs.createArgs,
+            data: params.data,
+            options: params.options,
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- implement `Fl32_Tmpl_Back_Service_Render_Web` to build the render target for web templates and delegate rendering
- document constructor dependencies with JSDoc

## Testing
- `npm run eslint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a66ac1cd8832da73f26c0c35577a7