### PR TITLE
Add locale-based web render service

### DIFF
--- a/src/Back/Service/Render/Web.js
+++ b/src/Back/Service/Render/Web.js
@@ -2,14 +2,12 @@ export default class Fl32_Tmpl_Back_Service_Render_Web {
     /* eslint-disable jsdoc/check-param-names */
     /**
      * @param {Fl32_Tmpl_Back_Dto_Target} dtoTarget - Target DTO factory.
-     * @param {Fl32_Tmpl_Back_Config} config - Templates configuration.
      * @param {Fl32_Tmpl_Back_Service_Render} serviceRender - Base render service.
-     * @param {typeof Fl32_Tmpl_Back_Enum_Type} TYPE
+     * @param {typeof Fl32_Tmpl_Back_Enum_Type} TYPE - Enum of template types.
      */
     constructor(
         {
             Fl32_Tmpl_Back_Dto_Target$: dtoTarget,
-            Fl32_Tmpl_Back_Config$: config,
             Fl32_Tmpl_Back_Service_Render$: serviceRender,
             Fl32_Tmpl_Back_Enum_Type$: TYPE,
         }
@@ -19,8 +17,8 @@ export default class Fl32_Tmpl_Back_Service_Render_Web {
          * Render a localized web template.
          * @param {object} args - Rendering parameters.
          * @param {string} args.name - Template filename with extension.
-         * @param {string} args.locale - User requested locale.
          * @param {string} [args.pkg] - Optional npm package name.
+         * @param {Fl32_Tmpl_Back_Dto_Locale.Dto} args.locales - Locale data object.
          * @param {object} [args.data] - Template context data.
          * @param {object} [args.options] - Engine specific render options.
          * @returns {Promise<{resultCode:string, content:string|null}>}
@@ -28,22 +26,17 @@ export default class Fl32_Tmpl_Back_Service_Render_Web {
         this.perform = async function (
             {
                 name,
-                locale,
                 pkg = '',
+                locales,
                 data = {},
                 options = {},
             }
         ) {
-            const defaultLocale = config.getDefaultLocale();
             const target = dtoTarget.create({
                 type: TYPE.WEB,
                 name,
                 pkg,
-                locales: {
-                    user: locale,
-                    app: defaultLocale,
-                    pkg: defaultLocale,
-                },
+                locales,
             });
 
             return serviceRender.perform({target, data, options});

--- a/test/unit/Back/Service/Render_Web.test.mjs
+++ b/test/unit/Back/Service/Render_Web.test.mjs
@@ -12,9 +12,6 @@ test.describe('Fl32_Tmpl_Back_Service_Render_Web', () => {
         container.register('Fl32_Tmpl_Back_Dto_Target$', {
             create: (args) => {logs.createArgs = args; return args;},
         });
-        container.register('Fl32_Tmpl_Back_Config$', {
-            getDefaultLocale: () => 'en',
-        });
         container.register('Fl32_Tmpl_Back_Service_Render$', {
             perform: async ({target, data, options}) => {
                 logs.performArgs = {target, data, options};
@@ -26,8 +23,8 @@ test.describe('Fl32_Tmpl_Back_Service_Render_Web', () => {
 
         const params = {
             name: 'index.html',
-            locale: 'en-US',
             pkg: '@vendor/cms',
+            locales: {user: 'ru-RU', app: 'ru', pkg: 'en'},
             data: {title: 'Hello'},
             options: {partials: {}},
         };
@@ -40,7 +37,7 @@ test.describe('Fl32_Tmpl_Back_Service_Render_Web', () => {
             type: 'web',
             name: 'index.html',
             pkg: '@vendor/cms',
-            locales: {user: 'en-US', app: 'en', pkg: 'en'},
+            locales: params.locales,
         });
         assert.deepStrictEqual(logs.performArgs, {
             target: logs.createArgs,


### PR DESCRIPTION
## Summary
- update `Fl32_Tmpl_Back_Service_Render_Web` to accept a prebuilt locale dto
- adjust unit test to reflect the new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a94f06700832da13fa78b51bdef53